### PR TITLE
fix(): use let instead of const since we re-assign

### DIFF
--- a/bin/stencil-dev-server
+++ b/bin/stencil-dev-server
@@ -5,7 +5,7 @@ process.title = 'stencil-dev-server';
 process.on('unhandledRejection', function(r) { console.error(r) });
 process.env.TINY_STATIC_LR_BIN = __filename;
 
-const cmdArgs = process.argv;
+let cmdArgs = process.argv;
 const npmRunArgs = process.env.npm_config_argv;
 if (npmRunArgs) {
   cmdArgs = cmdArgs.concat(JSON.parse(npmRunArgs).original);


### PR DESCRIPTION
fixes this error ```/Users/justinwillis/Projects/stencil-starter/node_modules/@stencil/dev-server/bin/stencil-dev-server:11
  cmdArgs = cmdArgs.concat(JSON.parse(npmRunArgs).original);
          ^

TypeError: Assignment to constant variable. ```