### PR TITLE
fix(build): point main at dist/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@stencil/dev-server",
   "version": "0.0.18-0",
   "description": "Tiny LiveReload server that watches a single directory",
-  "main": "index.js",
+  "main": "dist/index.js",
   "bin": {
     "stencil-dev-server": "./bin/stencil-dev-server"
   },


### PR DESCRIPTION
Build puts the index in the dist/ folder.

This change allows me to use this from node via `const server = require('@stencil/dev-server');` instead of `const server = require('@stencil/dev-server/dist');`