### PR TITLE
Select application/browser to open with opn

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ There are a number of options available, but all have sane defaults.
     - Defaults to false
 - **--no-open**
   - Disables automatically opening a browser.
+- **--app**
+  - Selects the application(browser) to open.
+  - Chrome: `chrome` on Windows, `google-chrome`on Linux, `google chrome` on macOS.
+  - Firefox: `firefox` on Windows.
 
 Config File Structure
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,10 @@ const optionInfo = {
   ssl: {
     default: false,
     type: Boolean
+  },
+  app: {
+    default: '',
+    type: String
   }
 }
 
@@ -109,7 +113,7 @@ export async function run(argv: string[]) {
   log(isVerbose, `serving: ${wwwRoot}`);
 
   if (argv.indexOf('--no-open') === -1) {
-    opn(`${protocol}://${browserUrl}:${foundHttpPort}`);
+    opn(`${protocol}://${browserUrl}:${foundHttpPort}`, {app: `${options.app}`});
   }
 
   if (argv.indexOf('--broadcast') >= 0) {


### PR DESCRIPTION
[Customize opn browser issue.](https://github.com/ionic-team/stencil-dev-server/issues/24)

This allows the user to specify which browser should open when running stencil-dev-server. I only have a windows machine so could only test the windows versions, but `--app chrome` and `--app firefox` worked for me. The [opn repo](https://github.com/sindresorhus/opn#app) specifies other OS commands for chrome, but not much else. 