### PR TITLE
Allow CORS when serving files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,8 @@ function createHttpRequestHandler(wwwDir: string, jsScriptsList: string[], html5
       return await sendHtml(filePath, req, res);
     }
     if (pathStat.isFile()) {
+      // Allow files to be loaded cross-origin
+      res.setHeader('Access-Control-Allow-Origin', '*');
       return staticFileMiddleware(req, res);
     }
 


### PR DESCRIPTION
This allows the dev server to serve its assets with CORS enabled. Useful when serving the compiled assets using stencil-dev-server and creating references to them when using another dev server e.g. webpack-dev-server.